### PR TITLE
Set up minimal Next.js skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# ss2buy.com_NextJS
+# ss2buy.com Next.js
+
+This repository contains a minimal [Next.js](https://nextjs.org/) setup. The project structure was generated manually because the environment did not allow installing packages directly from npm.
+
+## Getting Started
+
+1. Install dependencies (requires internet access):
+
+   ```bash
+   npm install
+   ```
+
+2. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+The app will be available at `http://localhost:3000`.
+
+## Project Structure
+
+- `pages/index.js` – main page returning a simple welcome message.
+- `package.json` – project metadata and scripts for running Next.js.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ss2buy.com_nextjs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Welcome to Next.js!</h1>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- initialize package.json and configure Next.js scripts
- add example page at `pages/index.js`
- document how to install and run the Next.js app
- ignore `node_modules` and `.next`

## Testing
- `npx create-next-app@latest . --use-npm --no-install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6851552d55dc832187ed3ae3a6bfc4af